### PR TITLE
Updated birth date for 13.txt

### DIFF
--- a/data/birth-dates/13.txt
+++ b/data/birth-dates/13.txt
@@ -1,1 +1,1 @@
-Gottlob Frege: 8 November ????
+Gottlob Frege: 8 November 1848


### PR DESCRIPTION
Updated birth date in 13.txt with Gottlob Frege: 8 November 1848.
