### PR TITLE
Added birth date for Grace Hopper

### DIFF
--- a/data/birth-dates/34.txt
+++ b/data/birth-dates/34.txt
@@ -1,1 +1,1 @@
-Grace Hopper: 9 December ????
+Grace Hopper: 9 December 1906


### PR DESCRIPTION
Updated 34.txt with Grace Hopper's birth year (1906) based on Wikipedia.
File: data/birth-dates/34.txt
Source: https://en.wikipedia.org/wiki/Grace_Hopper