### PR TITLE
Added missing birth date 

### DIFF
--- a/data/birth-dates/42.txt
+++ b/data/birth-dates/42.txt
@@ -1,1 +1,1 @@
-Shafrira Goldwasser: ????
+Shafrira Goldwasser: 1959


### PR DESCRIPTION
1959 is the correct birthday of Shafrira Goldwasser.